### PR TITLE
Add Author Identities model

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -922,6 +922,46 @@ definitions:
         description: Author name.
       icon:
         $ref: '#/definitions/Icon'
+      tities:
+        $ref: '#/definitions/AuthorIdentities'
+  AuthorIdentities:
+    title: Author Identities
+    description: Author nicknames in another social networks. Get dirrect from Spigot profile.
+    type: object
+    properties:
+      aim:
+        type: string
+        description: Outdated messanger.
+      discord:
+        type: string
+        description: Discord of the Author.
+      facebook:
+        type: string
+        description: Facebook of the Author.
+      github:
+        type: string
+        description: GitHub of the Author.
+      gtalk:
+        type: string
+        description: Outdated messanger.
+      icq:
+        type: string
+        description: Outdated messanger.
+      msn:
+        type: string
+        description: Outdated messanger.
+      skype:
+        type: string
+        description: Skype of the Author.
+      twitter:
+        type: string
+        description: Twitter of the Author.
+      yahoo:
+        type: string
+        description: Outdated messanger.
+      youtube:
+        type: string
+        description: YouTube of the Author.
   Category:
     title: Category
     description: Model for a Category.


### PR DESCRIPTION
This get from [non-official Spigot API](https://github.com/SpiGetOrg/SpigetResourceManagerFetcher/blob/48f5b8f8cee3b91b58bfafcc1a19ccc504c4d769/src/main/java/org/spiget/resourcemanagerfetcher/SpigetRestFetcher.java#L406), which gets this info from [this page of settings](https://www.spigotmc.org/account/contact-details). All possible values in GUI:
![image](https://user-images.githubusercontent.com/68118654/163872010-c3aa9256-8374-46f0-a4be-27a054a2b74f.png)
Thread about deleting closed and outdated messengers: https://www.spigotmc.org/threads/modern-profile-identities-fields.552439/